### PR TITLE
update acorn dependency so it works on node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "author": "Jon Jensen",
   "license": "MIT",
   "dependencies": {
-    "acorn": "~2.5.0",
-    "acorn-jsx": "^2.0.1",
+    "acorn": "~3.2.0",
+    "acorn-jsx": "^3.0.1",
     "estraverse": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
so that it works on things like this:

```
  $.each(data_points, function() {
    var date = new Date();
    date.setTime(this[0]);
    rows.push(
      //this ends up being [(a date), (the number of pageViews on that date), "an annotation tile, (if any)", ""]
      [date, this[1], undefined, undefined]
    )
  });
```

which would throw this when run on node 6 before:
/Users/ryan/code/canvas-lms/node_modules/acorn-jsx/node_modules/acorn/dist/acorn.js:945
  throw err;
        ^
SyntaxError: The keyword 'undefined' is reserved (276:21)

see: https://github.com/ternjs/acorn/issues/361
